### PR TITLE
PRMT-4342

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### 2024-Jan-09
+* Upgraded jdk to 21
+* Upgraded gradle to 8.5
+* Upgraded maven to 3.9.6
+
 ### 2023-Mar-28
 Upgraded gradle to 7.4.1
 

--- a/README.md
+++ b/README.md
@@ -2,23 +2,26 @@
 This is a fork of [Dojo](https://github.com/kudulab/dojo) docker image with Java build tools. 
 Repurposed for the NHSD needs to use LTS version of Java. 
 
-This docker image is based on `openjdk:17-jdk-buster`.
+This docker image is based on `openjdk:21-jdk-buster`.
 Images are published to dockerhub as `nhsdev/openjdk-dojo`.
 
 ## Specification
 This image has installed:
- * openjdk version 17
+ * OpenJDK Version 21
  * OpenJDK Runtime Environment
- * Gradle 7.4.1
- * Apache Maven 3.3.9
+ * Gradle 8.5
+ * Apache Maven 3.9.6
 
 ## Usage
 1. Install [Dojo](https://github.com/kudulab/dojo)
 On OSX, you can install with homebrew:
+
 ```
 brew install kudulab/homebrew-dojo-osx/dojo
 ```
+
 A manual install is another option:
+
 ```sh
 version="0.9.0"
 # on Linux:
@@ -28,13 +31,17 @@ wget -O /tmp/dojo https://github.com/kudulab/dojo/releases/download/${version}/d
 chmod +x /tmp/dojo
 mv /tmp/dojo /usr/bin/dojo
 ```
+
 2. Provide a Dojofile:
+
 ```
 DOJO_DOCKER_IMAGE="nhsdev/openjdk-dojo:<commit>"
 ```
+
 3. Create and enter the container by running dojo at the root of project.
    
 Run, example commands:
+
 ```bash
 dojo java -version
 dojo gradle --version
@@ -59,7 +66,7 @@ These files are used inside the docker image:
 
 ## License
 
-opyright 2020 Ewa Czechowska, Tomasz Sętkowski
+Copyright 2020 Ewa Czechowska, Tomasz Sętkowski
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17-jdk-buster
+FROM openjdk:21-jdk-buster
 
 ENV TINI_VERSION v0.19.0
 ARG TARGETPLATFORM
@@ -19,7 +19,7 @@ RUN apt-get update && \
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends nano
 
-ENV GRADLE_VERSION 7.4.1
+ENV GRADLE_VERSION 8.5
 ENV GRADLE_HOME /usr/lib/gradle/gradle-${GRADLE_VERSION}
 RUN cd /tmp &&\
   wget https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip &&\
@@ -27,7 +27,7 @@ RUN cd /tmp &&\
   rm gradle-${GRADLE_VERSION}-bin.zip &&\
   ln -s /usr/lib/gradle-${GRADLE_VERSION}/bin/gradle /usr/bin/gradle
 
-ENV MAVEN_VERSION 3.3.9
+ENV MAVEN_VERSION 3.9.6
 RUN cd /tmp/ &&\
   wget --quiet http://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.zip &&\
   unzip apache-maven-${MAVEN_VERSION}-bin.zip &&\

--- a/image/etc_dojo.d/variables/61-java-variables.sh
+++ b/image/etc_dojo.d/variables/61-java-variables.sh
@@ -2,6 +2,6 @@
 
 # those are set by a base image, but when using dojo, user may have overwritten
 # them, so set them again:
-export JAVA_HOME=/usr/local/openjdk-17
-export JAVA_VERSION=17.0.3
+export JAVA_HOME=/usr/local/openjdk-21
+export JAVA_VERSION=21-ea+26
 export PATH=$JAVA_HOME/bin:$PATH


### PR DESCRIPTION
- Updated the JDK to 21 LTS for buster.
- Updated Gradle version to 8.5 (supporting JDK 21).
- Updated Maven version to 3.9.6.
- Updated README.md and CHANGELOG.md to reflect changes.